### PR TITLE
Add CMake Vulkan detection step to CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,39 @@ jobs:
           echo DYLD_LIBRARY_PATH = $DYLD_LIBRARY_PATH
           echo Folder size = `du -hs $VULKAN_SDK`
 
+      - name: Verify Vulkan with CMake (Linux/macOS)
+        if: contains(matrix.config.OS, 'ubuntu') || contains(matrix.config.OS, 'mac')
+        run: |
+          mkdir -p cmake-test && cd cmake-test
+          cat > CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.10)
+          project(VulkanTest)
+          find_package(Vulkan REQUIRED)
+          message(STATUS "Vulkan found: ${Vulkan_FOUND}")
+          message(STATUS "Vulkan libraries: ${Vulkan_LIBRARIES}")
+          message(STATUS "Vulkan include dir: ${Vulkan_INCLUDE_DIR}")
+          message(STATUS "Vulkan version: ${Vulkan_VERSION}")
+          EOF
+          cmake .
+
+      - name: Verify Vulkan with CMake (Windows)
+        if: contains(matrix.config.OS, 'windows')
+        shell: pwsh
+        run: |
+          mkdir cmake-test
+          Set-Location cmake-test
+          $cmakeContent = @'
+          cmake_minimum_required(VERSION 3.10)
+          project(VulkanTest)
+          find_package(Vulkan REQUIRED)
+          message(STATUS "Vulkan found: ${Vulkan_FOUND}")
+          message(STATUS "Vulkan libraries: ${Vulkan_LIBRARIES}")
+          message(STATUS "Vulkan include dir: ${Vulkan_INCLUDE_DIR}")
+          message(STATUS "Vulkan version: ${Vulkan_VERSION}")
+          '@
+          Set-Content -Path CMakeLists.txt -Value $cmakeContent
+          cmake .
+
 # ---------------------------------------------------------------------------------------
 
   test-old-version: # makes sure the action works on a clean machine without building (user case)


### PR DESCRIPTION
<!-- 
🙏 Thank you for your contribution!

📌 Branch Selection Reminder:

Please remember to select the appropriate branch:
- For bug fixes use the oldest branch where the fix applies.
- For new features and everything else, use the main branch. 

-->

### What type of change is this?

- [ ] Bug Fix
- [x] New Feature

### Description:

After installing the Vulkan SDK, run cmake with a minimal project that uses find_package(Vulkan REQUIRED) to verify the package is properly detected on Linux, macOS, and Windows.

### Related Issues
#581 
